### PR TITLE
Update node package dependencies

### DIFF
--- a/libs/node/package.json
+++ b/libs/node/package.json
@@ -26,8 +26,8 @@
     "joi": "^17.6.0"
   },
   "peerDependencies": {
-    "mongoose": "^6.5.3",
-    "express": "^4.18.1"
+    "mongoose": "*",
+    "express": "*"
   },
   "files": [
     "src",


### PR DESCRIPTION
- Updated node package dependencies to allow any version of `mongoose` and `express`